### PR TITLE
Update Farcaster URLs to mini-bread-mint.vercel.app

### DIFF
--- a/farcaster.json
+++ b/farcaster.json
@@ -7,8 +7,8 @@
   "miniapp": {
     "version": "1",
     "name": "$BREAD",
-    "homeUrl": "https://bread-coop.vercel.app",
-    "iconUrl": "https://bread-coop.vercel.app/bread-coop-icon-1024.png",
+    "homeUrl": "https://mini-bread-mint.vercel.app",
+    "iconUrl": "https://mini-bread-mint.vercel.app/bread-coop-icon-1024.png",
     "subtitle": "Bake Bread on Gnosis",
     "description": "The future after capital. Mint and burn BREAD tokens on Gnosis Chain. Join the cooperative economy through mutual aid and solidarity.",
     "splashBackgroundColor": "#F5F0E8",

--- a/public/.well-known/farcaster.json
+++ b/public/.well-known/farcaster.json
@@ -7,8 +7,8 @@
   "miniapp": {
     "version": "1",
     "name": "$BREAD",
-    "homeUrl": "https://bread-coop.vercel.app",
-    "iconUrl": "https://bread-coop.vercel.app/bread-coop-icon-1024.png",
+    "homeUrl": "https://mini-bread-mint.vercel.app",
+    "iconUrl": "https://mini-bread-mint.vercel.app/bread-coop-icon-1024.png",
     "subtitle": "Bake Bread on Gnosis",
     "description": "The future after capital. Mint and burn BREAD tokens on Gnosis Chain. Join the cooperative economy through mutual aid and solidarity.",
     "splashBackgroundColor": "#F5F0E8",


### PR DESCRIPTION
Updated homeUrl and iconUrl in both farcaster.json files to use the correct deployment domain:
- Changed from bread-coop.vercel.app to mini-bread-mint.vercel.app