### PR TITLE
Fix: Use HTTP RPC for publicClient to resolve provider errors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { createPublicClient, createWalletClient, custom, formatEther, parseEther, type Hex } from 'viem';
+import { createPublicClient, createWalletClient, custom, http, formatEther, parseEther, type Hex } from 'viem';
 import sdk from '@farcaster/frame-sdk';
 import { gnosis } from './lib/chains';
 import { breadAbi } from './lib/breadAbi';
@@ -37,10 +37,12 @@ export default function Page() {
           console.log('Using Farcaster wallet provider');
           setProvider(farcasterProvider);
           
+          // Use HTTP RPC for reads and simulations
           setPublicClient(createPublicClient({
             chain: gnosis,
-            transport: custom(farcasterProvider),
+            transport: http('https://rpc.gnosischain.com'),
           }));
+          // Use wallet provider for signing
           setWalletClient(createWalletClient({
             chain: gnosis,
             transport: custom(farcasterProvider),
@@ -55,10 +57,12 @@ export default function Page() {
           console.log('Using window.ethereum provider');
           setProvider(window.ethereum);
           
+          // Use HTTP RPC for reads and simulations
           setPublicClient(createPublicClient({
             chain: gnosis,
-            transport: custom(window.ethereum),
+            transport: http('https://rpc.gnosischain.com'),
           }));
+          // Use wallet provider for signing
           setWalletClient(createWalletClient({
             chain: gnosis,
             transport: custom(window.ethereum),


### PR DESCRIPTION
Separated the viem client setup to fix "Provider does not support the requested method" errors:
- publicClient now uses HTTP RPC endpoint (https://rpc.gnosischain.com) for reads and simulations
- walletClient continues using the wallet provider (Farcaster or MetaMask) for signing

This resolves issues with balance fetching, contract reading, and transaction simulation that were failing because wallet providers don't support all required RPC methods.

🤖 Generated with [Claude Code](https://claude.ai/code)